### PR TITLE
Fix the Node.JS version (8 to 6) in the scl_enable script

### DIFF
--- a/contrib/bin/scl_enable
+++ b/contrib/bin/scl_enable
@@ -1,3 +1,3 @@
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-nodejs8
+source scl_source enable rh-nodejs6


### PR DESCRIPTION
The original image fails with the following error:

```
Can't read /etc/scl/conf/rh-nodejs8, rh-nodejs8 is probably not installed.
```

`node` executable can't be found.

This PR fixes this and makes `node` available by enabling the proper SCL.